### PR TITLE
Added "lh" and "slt" to their respective lists in Toolkit

### DIFF
--- a/riscv_assembler/utils.py
+++ b/riscv_assembler/utils.py
@@ -32,7 +32,7 @@ class Toolkit:
 	def __init__(self, filename = ""):
 		R_instr = [
 			"add","sub", "sll", 
-			"sltu", "xor", "srl", 
+			"slt", "sltu", "xor", "srl", 
 			"sra", "or", "and",
 			"addw", "subw", "sllw",
 			"slrw", "sraw", "mul",

--- a/riscv_assembler/utils.py
+++ b/riscv_assembler/utils.py
@@ -41,7 +41,7 @@ class Toolkit:
 			"remu"
 		]
 		I_instr = [
-			"addi", "lb", "lw",
+			"addi", "lb", "lh", "lw",
 			"ld", "lbu", "lhu",
 			"lwu", "fence", "fence.i", 
 			"slli", "slti", "sltiu", 


### PR DESCRIPTION
I think the "lh" instruction might have been left out in the I_instr list from Toolkit? Was using this library and when I tried to do:

`instr = tk.I_type("lh","x2","23","x3")`

It resulted in: 
```
File "/usr/local/lib/python3.6/dist-packages/riscv_assembler/utils.py", line 209, in I_type
    raise WrongInstructionType()
NameError: name 'WrongInstructionType' is not defined
```
Naïvely went ahead and added "lh" to the I_instr list from Toolkit and ran a test case - it seems to work as expected now with this PR applied:
```
>>> from riscv_assembler.utils import *
>>>
>>> tk = Toolkit()
>>> instr = tk.I_type("lh","x2","23","x3")
>>>
>>> instr
'00000001011100010001000110000011'
>>>
```

Let me know what you think? Also, thanks again for this library 😃 