### PR TITLE
Issues fix

### DIFF
--- a/riscv_assembler/convert.py
+++ b/riscv_assembler/convert.py
@@ -148,10 +148,25 @@ class AssemblyConverter:
 
 	#for jumps, calculates hex address of func
 	def calcJump(self, x,line_num):
-		#calc line number of func
-		for i in range(len(self.code)):
+		# search forward
+		skip_labels = 0
+		for i in range(line_num, len(self.code)):
 			if x+":" == self.code[i]:
-				return (i - line_num)*4 #how many instructions to jump ahead/behind
+				jump_size = (i - line_num - skip_labels) * 4 # how many instructions to jump ahead
+				return jump_size
+			if self.code[i].endswith(':'):
+				skip_labels += 1
+
+		# search backward
+		skip_labels = 0
+		for i in range(line_num, -1, -1):
+			# substruct correct label itself
+			if self.code[i].endswith(':'):
+				skip_labels += 1
+			if x+":" == self.code[i]:
+				jump_size = (i - line_num + skip_labels) * 4 # how many instructions to jump behind
+				return jump_size
+
 		#print("Address not found")
 		return -10 #if not found
 

--- a/riscv_assembler/convert.py
+++ b/riscv_assembler/convert.py
@@ -287,29 +287,27 @@ class AssemblyConverter:
 		])
 
 	def SB_type(
-			self, instr, rs1, 
+			self, instr, rs1,
 			rs2, imm):
 
 		if instr not in self.SB_instr:
 			raise WrongInstructionType()
 
-		opcode = 0;f3 = 1;f7 = 2
+		opcode = 0
+		f3 = 1
 
-		mod_imm = (int(imm) - ((int(imm) >> 12) << 12)) >> 6 # imm[12]
-		mod_imm += (int(imm) - ((int(imm) >> 11) >> 11)) >> 5 # imm[12|10:5]
-		mod_imm_2 = (int(imm) - ((int(imm) >> 5) << 5)) # imm[4:1]
-		mod_imm_2 += (int(imm) - ((int(imm) >> 11) << 11)) >> 10 # imm[4:1|11]
+		imm = format(((1 << 13) - 1) & imm, '013b') # represent `imm` as 13-bit in two's complement form
 
 		return "".join([
 			#"".join([
 			#	self.__binary(int(imm),13)[::-1][12][::-1],
 			#	self.__binary(int(imm),13)[::-1][5:11][::-1]
 			#]),
-			self.__binary(mod_imm,7),
+			imm[0], imm[12-10 : 12-4],
 			self.__reg_to_bin(rs2),
 			self.__reg_to_bin(rs1),
 			self.instr_data[instr][f3],
-			self.__binary(mod_imm_2,5),
+			imm[12-4 : 12-0], imm[1],
 			#"".join([
 			#	self.__binary(int(imm),13)[::-1][1:5][::-1],
 			#	self.__binary(int(imm),13)[::-1][11][::-1]
@@ -335,25 +333,23 @@ class AssemblyConverter:
 		])
 
 	def UJ_type(
-			self, instr, 
+			self, instr,
 			imm, rd):
 
 		if instr not in self.UJ_instr:
 			raise WrongInstructionType()
 
-		opcode = 0;f3 = 1;f7 = 2
+		opcode = 0
 
-		mod_imm = ((int(imm) - ((int(imm) >> 20) << 20)) >> 19) << 19 # imm[20]
-		mod_imm += (int(imm) - ((int(imm) >> 10) << 10)) >> 1 # imm[20|10:1]
-		mod_imm += (int(imm) - ((int(imm) >> 11) << 11)) >> 10 # imm[20|10:1|11]
-		mod_imm += (int(imm) - ((int(imm) >> 19) << 19)) >> 12 # imm[20|10:1|11|19:12]
+		imm = format(((1 << 21) - 1) & imm, '021b') # represent `imm` as 21-bit in two's complement form
+
 		return  "".join([
 			#"".join([
 			#	self.__binary(int(imm),21)[::-1][20][::-1], self.__binary(int(imm),21)[::-1][1:11][::-1],
 			#	self.__binary(int(imm),21)[::-1][11][::-1],
 			#	self.__binary(int(imm),21)[::-1][12:20][::-1]
-			#]),		
-			self.__binary(mod_imm,20),
+			#]),
+			imm[0], imm[20-10 : 20-0], imm[9], imm[20-19 : 20-11],
 			self.__reg_to_bin(rd),
 			self.instr_data[instr][opcode]
 		])


### PR DESCRIPTION
Closes #14 and #11.
`SB` and `UJ` immediate value is represented as described in [RISCV specification](https://riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf) (p.12, fig. 2.4).
For sanity check [this](https://riscvasm.lucasteske.dev/#) online compiler was used.